### PR TITLE
Change how StartLostWorld works.

### DIFF
--- a/SLWModLoader/src/Mainfrm.cs
+++ b/SLWModLoader/src/Mainfrm.cs
@@ -349,10 +349,9 @@ namespace SLWModLoader
             logfile.Add((closing)?"Closing mod loader and starting Sonic Lost World...":"Starting Sonic Lost World...");
             Invoke(new Action(() => { statuslbl.Text = "Starting SLW..."; }));
             Process slw = new Process();
-            slw.StartInfo = new ProcessStartInfo(slwdirectory + "\\Sonic Lost World.url");
+            new Process() { StartInfo = new ProcessStartInfo("steam://rungameid/329440") }.Start();
 
             Invoke((closing)?new Action(() => { Close(); }):new Action(() => { statuslbl.Text = ""; }));
-            slw.Start();
         }
 
         private void refreshlbl_Click(object sender, LinkLabelLinkClickedEventArgs e)


### PR DESCRIPTION
This makes it so it starts from a Steam URL instead of an internet shortcut
file. It should make it harder to use pirated Lost World copies with SLW
Mod Loader.